### PR TITLE
Fix main-thread Swift traps in refresh/response handlers

### DIFF
--- a/NightscoutMenuBar/NightscoutMenuBar.swift
+++ b/NightscoutMenuBar/NightscoutMenuBar.swift
@@ -444,9 +444,14 @@ func getProperties() {
                 return
             }
             DispatchQueue.main.async {
-                if let json = try! JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] {
-                    parseExtraInfo(properties: json)
+                // A 200 response can still carry a non-JSON body (captive portal,
+                // proxy/HTML error page), so decode defensively instead of force-trying.
+                guard let parsed = try? JSONSerialization.jsonObject(with: data, options: .allowFragments),
+                      let json = parsed as? [String: Any] else {
+                    print("Error: properties response was not valid JSON")
+                    return
                 }
+                parseExtraInfo(properties: json)
             }
         } else {
             DispatchQueue.main.async {
@@ -597,7 +602,10 @@ func bgValueFormatted(entry: Entry? = nil) -> String {
         print("Unknown direction: " + entry!.direction)
     }
     
-    if (displayShowBGDifference == true) {
+    // Only show a difference when we have at least two entries to compare.
+    // After waking from sleep or a CGM gap the response can contain a single
+    // in-window entry, in which case there is no prior reading to diff against.
+    if (displayShowBGDifference == true && store.entries.count > 1) {
         // Find the entry closest to 5 minutes ago
         let fiveMinutesAgo = store.entries[0].time.addingTimeInterval(-300) // 5 minutes = 300 seconds
         var closestIndex = 1 // Default to the second entry if we can't find a better match
@@ -672,21 +680,24 @@ func bgValueFormattedHistory(entry: Entry? = nil) -> String {
 }
 
 func bgMinsAgo(entry: Entry? = nil) -> String {
-    if (entry == nil) {
+    guard let entry = entry else {
         return ""
     }
-    
-    let fromNow = String(Int(minutesBetweenDates(entry!.time, Date())))
-    return fromNow
+
+    let minutesAgo = minutesBetweenDates(entry.time, Date())
+    guard minutesAgo.isFinite else {
+        return ""
+    }
+    return String(Int(minutesAgo))
 }
 
 func isStaleEntry(entry: Entry, staleThresholdMin: Int) -> Bool {
-    let fromNow = String(Int(minutesBetweenDates(entry.time, Date())))
-    if (Int(fromNow)! > staleThresholdMin) {
+    let minutesAgo = minutesBetweenDates(entry.time, Date())
+    // Guard against NaN/infinite values, which would trap when bridged to Int.
+    guard minutesAgo.isFinite else {
         return true
-    } else {
-        return false
     }
+    return minutesAgo > CGFloat(staleThresholdMin)
 }
 
 func minutesBetweenDates(_ oldDate: Date, _ newDate: Date) -> CGFloat {

--- a/NightscoutMenuBar/data/Entry.swift
+++ b/NightscoutMenuBar/data/Entry.swift
@@ -24,8 +24,8 @@ final class EntriesStore: ObservableObject {
         entries.sort { $0.time > $1.time }
     }
     
-    func getLatest() -> Entry {
-        return entries.max (by: { $0.time > $1.time })!
+    func getLatest() -> Entry? {
+        return entries.max(by: { $0.time < $1.time })
     }
     
     func createChartData() -> ChartData {


### PR DESCRIPTION
## Summary

Hardens the Nightscout refresh code paths against a family of `EXC_BREAKPOINT (SIGTRAP)` crashes on the main thread. These were reported on macOS 26.5 (3.3, build 38) and tend to fire right after the Mac wakes from sleep, when the first refresh response can be empty, stale, partial, or non‑JSON. The crash always lands inside a `DispatchQueue.main.async { … }` completion handler in `getEntries()` / `getProperties()`.

Changes:

- **`bgValueFormatted` — array index out of bounds (most likely culprit).** The BG‑difference path defaults `closestIndex = 1` and only updates it inside `for i in 1..<store.entries.count`. Because `makeEntry` drops any reading older than one hour, a post‑wake response with a CGM gap can leave a *single* in‑window entry, so the loop never runs and `store.entries[closestIndex]` reads `store.entries[1]` → trap. Now guarded with `store.entries.count > 1`.
- **`getProperties` — `try!` on JSON.** A `200` response can still carry a non‑JSON body (captive portal, proxy/HTML error page), and `try!` turns that into a fatal error. Switched to `try?` with a graceful bail‑out.
- **`isStaleEntry` / `bgMinsAgo` — fragile numeric conversion.** Removed the `String(Int(...))` → `Int(...)!` round‑trip and added an `isFinite` guard so a NaN/infinite interval can't trap when bridging `CGFloat` to `Int`.
- **`EntriesStore.getLatest()` — force‑unwrap.** Now returns `Entry?` instead of force‑unwrapping `max()` on a possibly empty array (also corrected the comparator so it actually returns the latest). The method has no other callers.

## Test plan

- [ ] Build the `NightscoutMenuBar` scheme in Xcode (couldn't run a full build in my environment — local Xcode `xcodebuild` is currently failing to load a plugin unrelated to this change; files pass `swiftc -parse`).
- [ ] Enable the "show BG difference" display option, then point at a server / simulate a response that yields a single reading within the last hour; confirm the menu bar updates instead of crashing.
- [ ] With Loop data enabled, return a non‑JSON `200` body for `/api/v2/properties` and confirm no crash.
- [ ] Sanity‑check normal operation (multiple recent entries, mmol and mg/dL, stale vs fresh) still displays as before.

Made with [Cursor](https://cursor.com)